### PR TITLE
force proxy mode maximum bytes to be even number

### DIFF
--- a/Inc/Proxy_driver.h
+++ b/Inc/Proxy_driver.h
@@ -38,7 +38,7 @@
 #include "usbd_conf.h"
 
 /*============ Defines ============*/
-#define NUMBYTES_RX_MP      (57)
+#define NUMBYTES_RX_MP      (56)
 #define NUMPROXYBYTES_TX     (4)
 #define NUMPROXYBYTES_RX    (63)
 


### PR DESCRIPTION
When performing multi-page reads of 3d data, Acquisition engine is permitted to return 0xFOOD or 0xBAAD if an address is busy. If this read is not word aligned, a word can be split across two reads. This can cause the first read to return 0xFO or 0xBA and the second read return the true value, or vice versa. This causes artifacts due to the inconsistency. Setting the maximum to an even number ensures that this does not occur.